### PR TITLE
allow setting default language which doesn't require url component

### DIFF
--- a/transurlvania/urlresolvers.py
+++ b/transurlvania/urlresolvers.py
@@ -233,6 +233,9 @@ class LangSelectionRegexURLResolver(MultilangRegexURLResolver):
 
     def get_regex(self, lang=None):
         lang = lang or get_language()
+        default_lang = getattr(settings, 'TRANSURLVANIA_DEFAULT_LANG', None)
+        if lang == default_lang:
+            return re.compile('^')
         return re.compile('^%s/' % lang)
     regex = property(get_regex)
 


### PR DESCRIPTION
Hi,

For a recent project I was working on using the LangInPathMiddleware the client required that pages in the default language _not_ have the language code added. This simple patch enables that so thought I'd offer it upstream incase you might be interested
